### PR TITLE
Add Pedro Corrêa section on about page

### DIFF
--- a/sobre.html
+++ b/sobre.html
@@ -22,6 +22,14 @@
             </div>
             <img src="https://via.placeholder.com/300" alt="Foto ilustrativa de Alexandre">
         </div>
+        <div class="sobre-container">
+            <div class="sobre-text">
+                <h2>Pedro Corrêa</h2>
+                <h3>Gestor de negócios apaixonado por inovação e tecnologia aplicada à saúde</h3>
+                <p>Pedro é um personagem fictício dedicado a transformar ideias em oportunidades que melhorem a vida das pessoas. Ele acredita que a tecnologia pode revolucionar o cuidado com a saúde e trabalha para conectar soluções inovadoras a quem mais precisa.</p>
+            </div>
+            <img src="https://via.placeholder.com/300" alt="Imagem ilustrativa de Pedro Corrêa">
+        </div>
     </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -55,11 +55,37 @@ button:hover {
     height: auto;
 }
 
+/* Sobre Container styles */
+.sobre-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.sobre-text {
+    max-width: 600px;
+    text-align: left;
+}
+
+.sobre-container img {
+    max-width: 300px;
+    width: 100%;
+    height: auto;
+}
+
 @media (max-width: 600px) {
     .intro {
         flex-direction: column;
     }
     .intro-text {
+        text-align: center;
+    }
+    .sobre-container {
+        flex-direction: column;
+    }
+    .sobre-text {
         text-align: center;
     }
 }


### PR DESCRIPTION
## Summary
- create a new `sobre-container` section with Pedro Corrêa bio
- style the new section with Flexbox and responsive behavior

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847abb096b48322a51d715f4d768987