### PR TITLE
Fix spelling of gallery image captions

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,12 +42,12 @@
         </form>
     </section>
     <div class="gallery">
-        <div class="gallery-item"><img src="https://picsum.photos/seed/1/600/400" alt="Imagem aleatoria 1" data-caption="Imagem aleatoria 1"></div>
-        <div class="gallery-item"><img src="https://picsum.photos/seed/2/600/400" alt="Imagem aleatoria 2" data-caption="Imagem aleatoria 2"></div>
-        <div class="gallery-item"><img src="https://picsum.photos/seed/3/600/400" alt="Imagem aleatoria 3" data-caption="Imagem aleatoria 3"></div>
-        <div class="gallery-item"><img src="https://picsum.photos/seed/4/600/400" alt="Imagem aleatoria 4" data-caption="Imagem aleatoria 4"></div>
-        <div class="gallery-item"><img src="https://picsum.photos/seed/5/600/400" alt="Imagem aleatoria 5" data-caption="Imagem aleatoria 5"></div>
-        <div class="gallery-item"><img src="https://picsum.photos/seed/6/600/400" alt="Imagem aleatoria 6" data-caption="Imagem aleatoria 6"></div>
+        <div class="gallery-item"><img src="https://picsum.photos/seed/1/600/400" alt="Imagem aleatória 1" data-caption="Imagem aleatória 1"></div>
+        <div class="gallery-item"><img src="https://picsum.photos/seed/2/600/400" alt="Imagem aleatória 2" data-caption="Imagem aleatória 2"></div>
+        <div class="gallery-item"><img src="https://picsum.photos/seed/3/600/400" alt="Imagem aleatória 3" data-caption="Imagem aleatória 3"></div>
+        <div class="gallery-item"><img src="https://picsum.photos/seed/4/600/400" alt="Imagem aleatória 4" data-caption="Imagem aleatória 4"></div>
+        <div class="gallery-item"><img src="https://picsum.photos/seed/5/600/400" alt="Imagem aleatória 5" data-caption="Imagem aleatória 5"></div>
+        <div class="gallery-item"><img src="https://picsum.photos/seed/6/600/400" alt="Imagem aleatória 6" data-caption="Imagem aleatória 6"></div>
     </div>
 
     <div id="image-modal" class="modal">


### PR DESCRIPTION
## Summary
- fix accented text in index gallery images

## Testing
- `grep -n "aleat" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_684f8239953c8322af65de0f564ce3a9