### PR TITLE
Fix mobile hamburger menu

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -21,5 +21,4 @@ function initMenu() {
     });
 }
 
-document.addEventListener('DOMContentLoaded', initMenu);
 window.initMenu = initMenu;


### PR DESCRIPTION
## Summary
- ensure initMenu is only triggered after dynamic menu loads

## Testing
- `python3 -m http.server 8001` *(fails: Address already in use)*
- `python3 -m http.server 8001`

------
https://chatgpt.com/codex/tasks/task_e_684f8919f61c8322b615945c87c9dac4